### PR TITLE
Adapt markdown format on call-for-tutorials 2015

### DIFF
--- a/src/site/2015/call-for-tutorials.html
+++ b/src/site/2015/call-for-tutorials.html
@@ -1,0 +1,29 @@
+<div class="row" media:type="text/omd">
+<div class="small-12 columns" media:type="text/omd">
+<h1 id="cufp-2015-call-for-tutorials">CUFP 2015 Call for Tutorials</h1>
+<p>Commercial Users of Functional Programming (CUFP) is an annual meeting co-located with the International Conference on Functional Programming which this year will take place in Vancouver, Canada on 3-5 September 2015. CUFP aims to bridge the gap between academia and users applying functional programming in practice. CUFP provides high-quality practical tutorials covering state-of-the-art techniques and tools for functional programming. There will be a mix of tutorials on introduction and advanced level, such that anyone that wants to learn something new has an opportunity to do so.</p>
+<p>We are seeking proposals for half-day tutorials to be presented during the first two days of the meeting, 3 and 4 September. Submission deadline is April 30th, but the earlier you submit, the better!</p>
+<p>Among the suggested topics for tutorials are:</p>
+<ul>
+<li><p>Introductions to functional programming languages. In the past we have had introductions to Clojure, Erlang, F#, Haskell, ML, OCaml, Scala, Scheme, Agda, Idris and others.</p></li>
+<li><p>Applying functional programming in particular areas, including the web, high-performance computing, finance.</p></li>
+<li><p>Tools and techniques supporting state of the art functional programming. In the past we have had tutorials on QuickCheck, Elm and others.</p></li>
+</ul>
+<p>Tutorial proposals should address the following points:</p>
+<ul>
+<li><p>Title</p></li>
+<li><p>Abstract (about 200 words) including</p>
+<ul>
+<li><p>Tutorial Objectives: by the end of this tutorial you will be able to …</p></li>
+<li><p>Intended audience: e.g. beginners, those with a working knowledge of X, …</p></li>
+<li><p>Speaker Bio: Joe Bloggs is ...</p></li>
+<li><p>Infrastructure required: For example, will participants need access to a particular system? Do they need to download anything prior to the tutorial? Can they be expected to have this on a laptop, or does it need to be provided by the meeting?</p></li>
+<li><p>Other minor information which will help us market your tutorial.</p></li>
+</ul></li>
+</ul>
+<p>Tutorials should be submitted using the following <a href="https://easychair.org/conferences/?conf=cufp2015">talk submission form</a>.</p>
+<p>If you have any questions, email Thomas Arts: thomas dot arts at quviq dot com or Román González: romanandreg at gmail dot com</p>
+<p>The 2015 conference is in Vancouver, Canada from September 3rd-5th. Once again, it is co-located with <a href="http://icfpconference.org/icfp2015/">ICFP 2015</a>.</p>
+<p>CUFP tweets <a href="https://twitter.com/cufpconference">@cufpconference</a>.</p>
+</div>
+</div>

--- a/src/site/2015/call-for-tutorials.md
+++ b/src/site/2015/call-for-tutorials.md
@@ -35,18 +35,18 @@ Tutorial proposals should address the following points:
 
 * Abstract (about 200 words) including
 
- - Tutorial Objectives: by the end of this tutorial you will be able to …
+    * Tutorial Objectives: by the end of this tutorial you will be able to …
 
- - Intended audience: e.g. beginners, those with a working knowledge of X, …
+    * Intended audience: e.g. beginners, those with a working knowledge of X, …
 
- - Speaker Bio: Joe Bloggs is ...
+    * Speaker Bio: Joe Bloggs is ...
 
- - Infrastructure required: For example, will participants need access
-  to a particular system? Do they need to download anything prior to
-  the tutorial? Can they be expected to have this on a laptop, or does
-  it need to be provided by the meeting?
+    * Infrastructure required: For example, will participants need access
+     to a particular system? Do they need to download anything prior to
+     the tutorial? Can they be expected to have this on a laptop, or does
+     it need to be provided by the meeting?
 
- - Other minor information which will help us market your tutorial.
+    * Other minor information which will help us market your tutorial.
 
 Tutorials should be submitted using the following [talk submission
 form](https://easychair.org/conferences/?conf=cufp2015).
@@ -58,7 +58,7 @@ The 2015 conference is in Vancouver, Canada from September
 3rd-5th. Once again, it is co-located with [ICFP
 2015](http://icfpconference.org/icfp2015/).
 
-CUFP tweets [@cufpconference](https://twitter.com/cufpconference).
+CUFP tweets [\@cufpconference](https://twitter.com/cufpconference).
 
 
 </div>


### PR DESCRIPTION
Hey Thomas,

Here are some small changes on the MD format to compile the intended HTML, I also added a version of the HTML being compiled by pandoc.

Can you send me an email when you push the changes about the rules of the call for tutorials? I'll go ahead and compile that. You may merge this PR.