### PR TITLE
Fix on call-for-tutorials.html document

### DIFF
--- a/src/site/2015/call-for-tutorials.html
+++ b/src/site/2015/call-for-tutorials.html
@@ -1,3 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta name="generator" content="pandoc" />
+  <title></title>
+  <style type="text/css">code{white-space: pre;}</style>
+</head>
+<body>
 <div class="row" media:type="text/omd">
 <div class="small-12 columns" media:type="text/omd">
 <h1 id="cufp-2015-call-for-tutorials">CUFP 2015 Call for Tutorials</h1>
@@ -27,3 +37,5 @@
 <p>CUFP tweets <a href="https://twitter.com/cufpconference">@cufpconference</a>.</p>
 </div>
 </div>
+</body>
+</html>


### PR DESCRIPTION
The encoding issues were happening because we were not putting the output HTML on a valid container, once we set a header with utf-8 it works as expected.

Cheers.